### PR TITLE
Change the way to specify inkwell version (branch name to commit hash)

### DIFF
--- a/wiz/Cargo.toml
+++ b/wiz/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm11-0"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", rev = "2d715ed", features = ["llvm11-0"] }
 either ="1.6.1"
 clap = "2.33.3"
 wiz_syntax = { path = "./wiz_syntax" }


### PR DESCRIPTION
Destructive changes to master branch prevented automated tests from running.